### PR TITLE
Fix /gexp failing

### DIFF
--- a/slashCommands/gexp.js
+++ b/slashCommands/gexp.js
@@ -30,7 +30,7 @@ module.exports = {
 
                 const embeds = [];
                 const pages = Number(toFixed((playerData.gexpHistory.length || 0) / 20)) + (((playerData.gexpHistory.length || 1) % 20) == 0 ? 0 : 1);
-                for (let i = 0; i < pages; i++) {
+                for (let i = 0; i <= pages; i++) {
                     const embed = new MessageEmbed()
                         .setTitle(`${lowerToNormal[playerInput.toLowerCase()]}'s Guild Exp`)
                         .setColor('BLURPLE')


### PR DESCRIPTION
Error happens if a member is in the guild but no guild experience history exists yet